### PR TITLE
Performance improvements

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -131,7 +131,7 @@ AddEventHandler('FiveM-Remote-Key:toggle', function()
 		SendNUIMessage({
 			display = false
 		})
-		SetNuiFocus(false)
+		SetNuiFocus(false, false)
 		keyOpen = false
 	else
 		SendNUIMessage({
@@ -142,13 +142,10 @@ AddEventHandler('FiveM-Remote-Key:toggle', function()
 	end
 end)
 
-Citizen.CreateThread(function()
-	while true do
-		Citizen.Wait(0)	
-		if IsControlJustPressed(0,311) then -- k
-			TriggerEvent('FiveM-Remote-Key:toggle')
-		end
-	end
+RegisterKeyMapping('togglekey', 'Toggle the car key', 'KEYBOARD', 'k')
+
+RegisterCommand('togglekey', function()
+	TriggerEvent('FiveM-Remote-Key:toggle')
 end)
 
 


### PR DESCRIPTION
By replacing the Citizen.Wait(0) while true loop with a command and RegisterKeyMapping the performance is cut down to 0.00 msec. This also makes it so that the player can bind the key to whatever button they want to in Settings > Keybinds > FiveM.
Added second parameter to SetNuiFocus to make sure the cursor is getting hidden (This probably won't work if there are 2 NUI being show with the same button press)